### PR TITLE
Make schedule() not return to kernel thread

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -5,7 +5,6 @@ pub fn schedule() {
         fn swtch(old: usize, new: usize);
     }
 
-    println!("Scheduling");
     let mut tm = TASK_MANAGER.lock();
     let (old, new) = tm.switch_task();
     drop(tm);

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -4,6 +4,24 @@ use crate::sched::schedule;
 use config::std_io::*;
 use config::syscall::*;
 
+struct DispOut;
+
+impl core::fmt::Write for DispOut {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for c in s.chars() {
+            crate::graphics::putc(c);
+        }
+        Ok(())
+    }
+}
+
+macro_rules! uprint {
+    ($($arg:tt)*) => ({
+        use core::fmt::Write;
+        $crate::syscall::DispOut.write_fmt(format_args!($($arg)*)).unwrap();
+    });
+}
+
 pub fn do_syscall(context: &mut TrapFrame) {
     match context.regs[SYSCALL_REG_NUM] {
         SYSCALL_EXIT => {
@@ -23,7 +41,7 @@ pub fn do_syscall(context: &mut TrapFrame) {
             unsafe {
                 match fd {
                     STDOUT | STDERR => {
-                        print!(
+                        uprint!(
                             "{}",
                             core::str::from_utf8_unchecked(core::slice::from_raw_parts(p, len))
                         );

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -8,8 +8,9 @@ struct DispOut;
 
 impl core::fmt::Write for DispOut {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let mut tb = crate::graphics::TEXT_BUFFER.lock();
         for c in s.chars() {
-            crate::graphics::putc(c);
+            tb.putc(c);
         }
         Ok(())
     }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -25,7 +25,9 @@ macro_rules! uprint {
 pub fn do_syscall(context: &mut TrapFrame) {
     match context.regs[SYSCALL_REG_NUM] {
         SYSCALL_EXIT => {
-            println!("exit code: {}", context.regs[SYSCALL_REG_RET]);
+            let tm = crate::task::TASK_MANAGER.lock();
+            debug!("Task {} exited with code: {}", tm.current_pid, context.regs[SYSCALL_REG_RET]);
+            drop(tm);
             schedule();
         }
         SYSCALL_GETPID => {

--- a/kernel/src/task.rs
+++ b/kernel/src/task.rs
@@ -38,7 +38,7 @@ pub fn loop_print() -> ! {
             );
         }
         for _ in 0..10000 {
-            for _ in 0..100000 {
+            for _ in 0..10000 {
                 unsafe {
                     asm!("nop");
                 }


### PR DESCRIPTION
Existing bug: Context switch is incorrect after each task is scheduled once.

<img width="338" alt="image" src="https://github.com/SIG-SPL/rv6/assets/55489976/67f46579-ab32-4d86-8ccc-1bf2bee0e7e0">

<img width="166" alt="image" src="https://github.com/SIG-SPL/rv6/assets/55489976/3dcd5cd7-f915-4b03-a657-6e3a9e0e9038">

sth. wrong with the user stack
